### PR TITLE
Add a new "breakpoint_resolved" notification

### DIFF
--- a/debugger_protocol.rst
+++ b/debugger_protocol.rst
@@ -2009,13 +2009,13 @@ debugger engine to IDE::
 8.5 Notifications
 -----------------
 
-At times it may be desirable to recieve a notification from the debugger
+At times it may be desirable to receive a notification from the debugger
 engine for various events.  This notification tag allows for some simple
 data to be passed from the debugger engine to the IDE.  Customized
 implementations may add child elements for additional data.
 
-As an example, this is usefull for handling STDIN.  The debugger engine
-interupts all STDIN reads, and when a read is done by the application, it sends
+As an example, this is useful for handling STDIN.  The debugger engine
+interrupts all STDIN reads, and when a read is done by the application, it sends
 a notification to the IDE.  The IDE is then able to do something to let the user
 know the application is waiting for input, such as placing a cursor in the
 debugger output window.
@@ -2051,7 +2051,7 @@ debugger engine notifications to IDE::
 
 The following list of notifications are standardized for the protocol. Other
 notifications may be added by other implementations.  It is suggested that
-notification names not found in this document are preceeded with 'XXX' or some
+notification names not found in this document are preceded with 'XXX' or some
 similar tag as a means of preventing name conflicts when new notifications get
 added to the protocol in the future.
 

--- a/debugger_protocol.rst
+++ b/debugger_protocol.rst
@@ -514,7 +514,7 @@ The following are predefined error codes for the response to commands:
     1 - parse error in command
     2 - duplicate arguments in command
     3 - invalid options (ie, missing a required option, invalid value for a 
-        passed option)
+        passed option, not supported feature)
     4 - Unimplemented command
     5 - Command not available (Is used for async commands. For instance
         if the engine is in state "run" then only "break" and "status"
@@ -737,7 +737,7 @@ assume that the feature is not available:
                                       information on properties (eg. private
                                       members of classes, etc.)  Zero means that
                                       hidden members are not shown to the IDE.
-    notify_ok                 get|set [0|1]  See section 8.5
+    notify_ok                 get|set [0|1]  See section `8.5 Notifications`_.
     ========================= ======= ==========================================
 
 Additionally, all protocol commands supported must have a string,
@@ -817,6 +817,8 @@ debugger engine ::
               success="0|1"
               transaction_id="transaction_id"/>
 
+If the feature is not supported, the debugger engine should return an error
+with the code set to 3 (invalid arguments).
 
 7.5 continuation commands
 -------------------------
@@ -2024,7 +2026,9 @@ A new feature name is introduced: notify_ok.  The IDE will call feature_set
 with the notify_ok name and a TRUE value (1).  This lets the debugger engine
 know that it can send notifications to the IDE.  If the IDE has not set this
 value, or sets it to FALSE (0), then the debugger engine MUST NOT send
-notifications to the IDE.
+notifications to the IDE. If the debugger engine does not understand the
+notify_ok feature, the call to feature_set should return an error with the
+error code set to 3 (invalid arguments).
 
 The debugger engine MUST NOT expect a notification to cause an IDE to behave
 in any particular way, or even to be handled by the IDE at all.

--- a/debugger_protocol.rst
+++ b/debugger_protocol.rst
@@ -2059,12 +2059,22 @@ notification names not found in this document are preceded with 'XXX' or some
 similar tag as a means of preventing name conflicts when new notifications get
 added to the protocol in the future.
 
-    ======= =====================================================
-    Name    Description
-    ======= =====================================================
-    stdin   notification occurs when the debugger engine is about
-            to read the stdin pipe.
-    ======= =====================================================
+    =================== =====================================================
+    Name                Description
+    =================== =====================================================
+    stdin               notification occurs when the debugger engine is about
+                        to read the stdin pipe.
+    resolved_breakpoint Notification occurs when the debugger engine has
+                        resolved a breakpoint. The returned notification
+                        includes the same elements as a return from
+                        `7.6.2 breakpoint_get`_. The *breakpoint* element
+                        becomes a child element of the *notify* element
+                        instead of *response*. The *resolved* attribute should
+                        always be set to *resolved*.
+                        A debugger engine MAY send multiple notifications for
+                        the same breakpoint ID, but only if their attributes
+                        have changed (again).
+    =================== =====================================================
 
 
 8.6 interact - Interactive Shell

--- a/debugger_protocol.rst
+++ b/debugger_protocol.rst
@@ -2064,7 +2064,7 @@ added to the protocol in the future.
     =================== =====================================================
     stdin               notification occurs when the debugger engine is about
                         to read the stdin pipe.
-    resolved_breakpoint Notification occurs when the debugger engine has
+    breakpoing_resolved Notification occurs when the debugger engine has
                         resolved a breakpoint. The returned notification
                         includes the same elements as a return from
                         `7.6.2 breakpoint_get`_. The *breakpoint* element


### PR DESCRIPTION
This new notification can be used to discover when breakpoints are resolved (see #8).

It is a better alternative to a combination of using the scope breakpoint from #9 in combination with breakpoint_list/breakpoint_get to find out whether breakpoints have been resolved. It does require IDEs to implement an additional top-level element (notification) in the debugging protocol however.

A debugger engine is not required to implement "breakpoint_resolved" notifications (or rather, any notifications at all).
