### PR TITLE
Add optional -d stack depth parameter to eval command

### DIFF
--- a/debugger_protocol.rst
+++ b/debugger_protocol.rst
@@ -1785,12 +1785,14 @@ as Python, which have separate statements for these, will need to handle
 both appropriately.  For implementations that need to be more explicit, use
 the expr or exec commands below.
 
-The eval and expr commands can include the following optional parameter:
+The eval and expr commands can include the following optional parameters:
 
     ==      ===============================================================
     -p      data page: optional for arrays, hashes, objects, etc.; debugger
             engine should assume zero if not provided — similar to the -p
             parameter for property_get.
+    -d      stack depth: stack depth at which the given code should be
+            evaluated; debugger engine should assume zero if not provided.
     ==      ===============================================================
 
 IDE ::


### PR DESCRIPTION
The motivation here is that:

1. Eval'ing at different stack depths is a useful thing to provide, and
2. Any reasonable implementation should be able to provide this.